### PR TITLE
BugFix: GPU vs CPU device error

### DIFF
--- a/tricicl/cil_memory/strategy/closest_to_center.py
+++ b/tricicl/cil_memory/strategy/closest_to_center.py
@@ -8,7 +8,8 @@ from tricicl.models.feature_based_module import FeatureBasedModule
 
 class ClosestToCenterMemoryStrategy(CILMemoryStrategyABC):
     def select(self, dataset: AvalancheSubset, model: FeatureBasedModule, m: int) -> AvalancheSubset:
-        features = cat([model.featurize(images) for images, *_ in DataLoader(dataset, batch_size=32)])
+        model_device = next(model.parameters()).device
+        features = cat([model.featurize(images.to(model_device)) for images, *_ in DataLoader(dataset, batch_size=32)])
         center = features.mean(dim=0)
         distances = pow(features - center, 2).sum(dim=1)
         return AvalancheSubset(dataset, distances.argsort()[:m])

--- a/tricicl/cil_memory/strategy/herding.py
+++ b/tricicl/cil_memory/strategy/herding.py
@@ -10,7 +10,8 @@ from tricicl.models.feature_based_module import FeatureBasedModule
 
 class HerdingMemoryStrategy(CILMemoryStrategyABC):
     def select(self, dataset: AvalancheSubset, model: FeatureBasedModule, m: int) -> AvalancheSubset:
-        features = cat([model.featurize(images) for images, *_ in DataLoader(dataset, batch_size=32)])
+        model_device = next(model.parameters()).device
+        features = cat([model.featurize(images.to(model_device)) for images, *_ in DataLoader(dataset, batch_size=32)])
         center = features.mean(dim=0)
         current_center = center * 0
         indices = []

--- a/tricicl/models/nme/nme.py
+++ b/tricicl/models/nme/nme.py
@@ -12,6 +12,7 @@ class NME(FeatureBasedModule):
         self.base_module = base_module
         self.class_ids: Tensor = None
         self.centers: Tensor = None
+        self.device = next(self.base_module.parameters()).device
 
     def featurize(self, x: Tensor) -> Tensor:
         return self.base_module.featurize(x)
@@ -21,7 +22,7 @@ class NME(FeatureBasedModule):
             return self.base_module.classify(features)
 
         p = stack([1 / torch.pow(feature - self.centers, 2).sum(dim=1) for feature in features])
-        proba = zeros(len(p), self.n_classes)
+        proba = zeros(len(p), self.n_classes, device=self.device)
         proba[:, self.class_ids] = p
         return proba
 

--- a/tricicl/models/nme/plugin.py
+++ b/tricicl/models/nme/plugin.py
@@ -28,10 +28,10 @@ class NMEPlugin(StrategyPlugin):
         self.nme.eval()
         centers, class_ids = [], []
         for class_id, dataset in self.memory.class_id2dataset.items():
-            center = torch.zeros(self.nme.base_module.features_size)
+            center = torch.zeros(self.nme.base_module.features_size, device=self.nme.device)
             n_images = len(dataset)
             for images, *_ in DataLoader(dataset, batch_size=strategy.eval_mb_size):
-                center += self.nme.base_module.featurize(images).sum(dim=0) / n_images
+                center += self.nme.base_module.featurize(images.to(self.nme.device)).sum(dim=0) / n_images
             centers.append(center)
             class_ids.append(class_id)
         self.nme.centers = stack(centers)

--- a/tricicl/research/mathieu/benchmark_split_mnist.py
+++ b/tricicl/research/mathieu/benchmark_split_mnist.py
@@ -38,10 +38,7 @@ def evaluate(name: str, plugins: List[StrategyPlugin]):
                 num_classes=perm_mnist.n_classes,
                 image_creator=SortedCMImageCreator(perm_mnist.classes_order),
             ),
-            loggers=[
-                InteractiveLogger(),
-                TensorboardLogger(TB_DIR / "split_mnist" / name),
-            ],
+            loggers=[InteractiveLogger(), TensorboardLogger(TB_DIR / "split_mnist" / name)],
         ),
     )
 

--- a/tricicl/research/mathieu/benchmark_split_mnist.py
+++ b/tricicl/research/mathieu/benchmark_split_mnist.py
@@ -1,7 +1,8 @@
+from typing import List
+
 import torch
 from avalanche.benchmarks.classic import SplitMNIST
-from avalanche.evaluation.metrics import (StreamConfusionMatrix,
-                                          accuracy_metrics)
+from avalanche.evaluation.metrics import StreamConfusionMatrix, accuracy_metrics
 from avalanche.logging import InteractiveLogger, TensorboardLogger
 from avalanche.training import EvaluationPlugin
 from avalanche.training.plugins import LwFPlugin, ReplayPlugin, StrategyPlugin
@@ -19,7 +20,7 @@ device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 perm_mnist = SplitMNIST(n_experiences=5)
 
 
-def evaluate(name: str, plugins: list[StrategyPlugin]):
+def evaluate(name: str, plugins: List[StrategyPlugin]):
     model = SimpleMLP(n_classes=perm_mnist.n_classes, input_size=28 * 28)
 
     cl_strategy = Naive(
@@ -34,9 +35,13 @@ def evaluate(name: str, plugins: list[StrategyPlugin]):
         evaluator=EvaluationPlugin(
             accuracy_metrics(experience=True, stream=True),
             StreamConfusionMatrix(
-                num_classes=perm_mnist.n_classes, image_creator=SortedCMImageCreator(perm_mnist.classes_order),
+                num_classes=perm_mnist.n_classes,
+                image_creator=SortedCMImageCreator(perm_mnist.classes_order),
             ),
-            loggers=[InteractiveLogger(), TensorboardLogger(TB_DIR / "split_mnist" / name)],
+            loggers=[
+                InteractiveLogger(),
+                TensorboardLogger(TB_DIR / "split_mnist" / name),
+            ],
         ),
     )
 


### PR DESCRIPTION
There is a bug in the `benchmark_split_mnist.py` when running the `iCaRL` evaluation on GPU, here is the stack error:
```
Traceback (most recent call last):
  File "benchmark_split_mnist.py", line 49, in <module>
    evaluate("iCaRL", make_icarl_plugins(memory_size=200))
  File "benchmark_split_mnist.py", line 44, in evaluate
    cl_strategy.train(train_task, num_workers=0)
  File "/usr/local/lib/python3.7/dist-packages/avalanche/training/strategies/base_strategy.py", line 249, in train
    self.train_exp(exp, eval_streams, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/avalanche/training/strategies/base_strategy.py", line 285, in train_exp
    self.after_training_exp(**kwargs)
  File "/usr/local/lib/python3.7/dist-packages/avalanche/training/strategies/base_strategy.py", line 492, in after_training_exp
    p.after_training_exp(self, **kwargs)
  File "/content/tricicl/cil_memory/plugin.py", line 23, in after_training_exp
    self._add_experience_to_memory(strategy.experience, strategy.model)
  File "/content/tricicl/cil_memory/plugin.py", line 29, in _add_experience_to_memory
    subset, model, min(self.memory.m, len(experience.dataset)),
  File "/content/tricicl/cil_memory/strategy/herding.py", line 13, in select
    features = cat([model.featurize(images) for images, *_ in DataLoader(dataset, batch_size=32)])
  File "/content/tricicl/cil_memory/strategy/herding.py", line 13, in <listcomp>
    features = cat([model.featurize(images) for images, *_ in DataLoader(dataset, batch_size=32)])
  File "/content/tricicl/models/nme/nme.py", line 17, in featurize
    return self.base_module.featurize(x)
  File "/content/tricicl/models/simple_mlp.py", line 17, in featurize
    x = self.featurizer(x)
  File "/usr/local/lib/python3.7/dist-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/torch/nn/modules/container.py", line 119, in forward
    input = module(input)
  File "/usr/local/lib/python3.7/dist-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/torch/nn/modules/linear.py", line 94, in forward
    return F.linear(input, self.weight, self.bias)
  File "/usr/local/lib/python3.7/dist-packages/torch/nn/functional.py", line 1753, in linear
    return torch._C._nn.linear(input, weight, bias)
RuntimeError: Tensor for argument #2 'mat1' is on CPU, but expected it to be on GPU (while checking arguments for addmm)
```