### PR TITLE
record featurized vectors for NME models instead of logits

### DIFF
--- a/src/tricicl/metrics/representation_shift.py
+++ b/src/tricicl/metrics/representation_shift.py
@@ -7,6 +7,7 @@ from avalanche.evaluation.metric_results import MetricValue, MetricResult
 from avalanche.evaluation.metric_utils import get_metric_name
 from avalanche.training.strategies import BaseStrategy
 from torch import Tensor
+from tricicl.models.feature_based_module import FeatureBasedModule
 
 
 class Representation:
@@ -209,7 +210,10 @@ class ExperienceMeanRepresentationShift(PluginMetric[Dict[int, float]]):
     def after_eval_iteration(self, strategy: "BaseStrategy") -> None:
         super().after_eval_iteration(strategy)
         self.eval_exp_id = strategy.experience.current_experience
-        self._current_representation.update(logits=strategy.logits)
+        if isinstance(strategy.model, FeatureBasedModule):
+            self._current_representation.update(logits=strategy.model.featurize(strategy.mb_x))
+        else:
+            self._current_representation.update(logits=strategy.logits)
 
     def after_eval_exp(self, strategy: "BaseStrategy") -> MetricResult:
         # update experience on which training just ended


### PR DESCRIPTION
When recording/updating the representations for `FeatureBasedModule` models we will add the `featurize` vectors instead of the `logits` as the logits are meaningless for these models. 

Below we can see the comparison between iCaRL running on the new code and iCaRL-mean, which was ran on the old code. We can see that the shift is no longer flat on zero for the new code.
![Screenshot from 2021-04-28 19-20-16](https://user-images.githubusercontent.com/29124068/116484401-fb32db00-a856-11eb-9939-1a862b5015e8.png)
 